### PR TITLE
Add stats tracking and color customization

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,6 +1,9 @@
 <info-panel (start)="canvas.start()" (stop)="canvas.stop()">
 </info-panel>
 <side-panel (start)="canvas.start()" (stop)="canvas.stop()" (speedChange)="canvas.setSpeed($event)"
-  (patternSelected)="canvas.selectPattern($event)">
+  (patternSelected)="canvas.selectPattern($event)"
+  (colorEnabledChange)="canvas.setColorEnabled($event)"
+  (baseHueChange)="canvas.setBaseHue($event)"
+  (bgColorChange)="canvas.setBgColor($event)">
 </side-panel>
 <game-canvas #canvas></game-canvas>

--- a/src/app/components/game-canvas/game-canvas.html
+++ b/src/app/components/game-canvas/game-canvas.html
@@ -1,1 +1,1 @@
-<canvas #canvas></canvas>
+<canvas #canvas [style.background]="bgColor()"></canvas>

--- a/src/app/components/game-canvas/game-canvas.scss
+++ b/src/app/components/game-canvas/game-canvas.scss
@@ -5,6 +5,6 @@
 }
 canvas {
   width: 100%;
-  height: Calc(100vh - 20px);
+  height: 100vh;
   z-index: 1;
 }

--- a/src/app/components/info-panel/info-panel.html
+++ b/src/app/components/info-panel/info-panel.html
@@ -1,4 +1,11 @@
 <div class="panel">
-    <a href="https://entropymine.com/jason/life/p/jslife-20121230.zip">Jason Summers’s Collection</a>
-    <button class="menu-toggle" type="button" (click)="toggleMenu()">></button>
+  <div class="stats">
+    <span>Gen: {{ step() }}</span>
+    <span>Nacidas: {{ born() }}</span>
+    <span>Muertas: {{ died() }}</span>
+    <span>B/M: {{ ratio() | number:'1.2-2' }}</span>
+    <span>Vivas: {{ alive() }}</span>
+  </div>
+  <a href="https://entropymine.com/jason/life/p/jslife-20121230.zip">Jason Summers’s Collection</a>
+  <button class="menu-toggle" type="button" (click)="toggleMenu()">></button>
 </div>

--- a/src/app/components/info-panel/info-panel.scss
+++ b/src/app/components/info-panel/info-panel.scss
@@ -8,3 +8,9 @@
   flex-direction: row;
   gap: 30px;
 }
+
+.stats {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+}

--- a/src/app/components/info-panel/info-panel.spec.ts
+++ b/src/app/components/info-panel/info-panel.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { InfoPanel } from './info-panel';
+import { InfoPanelComponent } from './info-panel';
 
-describe('InfoPanel', () => {
-  let component: InfoPanel;
-  let fixture: ComponentFixture<InfoPanel>;
+describe('InfoPanelComponent', () => {
+  let component: InfoPanelComponent;
+  let fixture: ComponentFixture<InfoPanelComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [InfoPanel]
+      imports: [InfoPanelComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(InfoPanel);
+    fixture = TestBed.createComponent(InfoPanelComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/components/info-panel/info-panel.ts
+++ b/src/app/components/info-panel/info-panel.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Output, computed } from '@angular/core';
 import { GameOfLifeService } from '../../services/game-of-life';
 
 @Component({
@@ -10,6 +10,15 @@ import { GameOfLifeService } from '../../services/game-of-life';
 export class InfoPanelComponent {
   @Output() start = new EventEmitter<void>();
   @Output() stop = new EventEmitter<void>();
+
+  step = this.game.stepCount;
+  born = this.game.bornTotal;
+  died = this.game.diedTotal;
+  alive = computed(() => this.game.cells().size);
+  ratio = computed(() => {
+    const d = this.died();
+    return d === 0 ? 0 : this.born() / d;
+  });
 
   constructor(public game: GameOfLifeService) {
     this.game = game;

--- a/src/app/components/side-panel/side-panel.html
+++ b/src/app/components/side-panel/side-panel.html
@@ -24,13 +24,26 @@
       <input type="number" [value]="speed()" (input)="onSpeedChange($event)" min="1" max="120"/>
     </label>
 
-    <h3>Patrones</h3>
-    <select (change)="onPatternChange($event)">
-      <option value="">Seleccione...</option>
-      @for (p of patterns(); track p.name) {
-        <option [value]="p.name">{{ p.name }}</option>
-      }
-    </select>
+  <h3>Patrones</h3>
+  <select (change)="onPatternChange($event)">
+    <option value="">Seleccione...</option>
+    @for (p of patterns(); track p.name) {
+      <option [value]="p.name">{{ p.name }}</option>
+    }
+  </select>
+
+  <h3>Visualización</h3>
+  <label>
+    <input type="checkbox" [checked]="colorEnabled()" (change)="onColorEnabledChange($event)" /> Usar colores
+  </label>
+  <label>
+    Color base:
+    <input type="color" [value]="baseColor()" (input)="onBaseColorChange($event)" />
+  </label>
+  <label>
+    Fondo:
+    <input type="color" [value]="background()" (input)="onBgColorChange($event)" />
+  </label>
 
     <h3>Controles</h3>
     <button type="button" (click)="start.emit()">Play</button>

--- a/src/app/components/side-panel/side-panel.scss
+++ b/src/app/components/side-panel/side-panel.scss
@@ -8,7 +8,8 @@
   top: 0;
   left: 1rem;
   z-index: 1000;
-  background: none;
+  background: #333;
+  color: #fff;
   border: none;
   font-size: 1.5rem;
   padding: 0.2rem 0.5rem;
@@ -20,18 +21,21 @@
   overflow: hidden;
   width: 250px;
   padding: 1rem;
-  background: #f5f5f5;
-  height: 95vh;
+  background: #222;
+  color: #eee;
+  height: 100vh;
   position: absolute;
   top: 0;
   left: 0;
   transform: translateX(-105%);
   transition: transform 0.3s;
-  box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+  box-shadow: 2px 0 5px rgba(0,0,0,0.5);
 }
 
 .panel h3 {
   margin-top: 1rem;
+  border-bottom: 1px solid #444;
+  padding-bottom: 0.2rem;
 }
 
 .panel label {
@@ -40,9 +44,14 @@
 }
 
 .panel button,
-.panel select {
+.panel select,
+.panel input {
   margin: 0.2rem 0;
   width: 100%;
+  background: #333;
+  color: #fff;
+  border: none;
+  padding: 0.2rem;
 }
 
 .panel input[type="text"]  {

--- a/src/app/components/side-panel/side-panel.ts
+++ b/src/app/components/side-panel/side-panel.ts
@@ -56,6 +56,10 @@ export class SidePanelComponent {
 
   open = signal(false);
 
+  colorEnabled = signal(true);
+  baseColor = signal('#ff0000');
+  background = signal('#000000');
+
     // 1) Lista de presets, con “Conway’s Life” seleccionado por defecto
   rulePresets: RulePreset[] = [
     { name: 'Conway’s Life',        survive: [2,3],     born: [3]    },
@@ -75,6 +79,9 @@ export class SidePanelComponent {
   @Output() stop = new EventEmitter<void>();
   @Output() speedChange = new EventEmitter<number>();
   @Output() patternSelected = new EventEmitter<[number, number][]>();
+  @Output() colorEnabledChange = new EventEmitter<boolean>();
+  @Output() baseHueChange = new EventEmitter<number>();
+  @Output() bgColorChange = new EventEmitter<string>();
 
   constructor(public game: GameOfLifeService) {
     // cada vez que cambien survive/born aplico reglas automáticamente
@@ -114,6 +121,24 @@ export class SidePanelComponent {
     this.speedChange.emit(v);
   }
 
+  onColorEnabledChange(e: Event) {
+    const v = (e.target as HTMLInputElement).checked;
+    this.colorEnabled.set(v);
+    this.colorEnabledChange.emit(v);
+  }
+
+  onBaseColorChange(e: Event) {
+    const hex = (e.target as HTMLInputElement).value;
+    this.baseColor.set(hex);
+    this.baseHueChange.emit(this.hexToHue(hex));
+  }
+
+  onBgColorChange(e: Event) {
+    const hex = (e.target as HTMLInputElement).value;
+    this.background.set(hex);
+    this.bgColorChange.emit(hex);
+  }
+
   toggleMenu() { this.open.set(!this.open()); }
 
   selectPattern(pattern: Pattern) {
@@ -138,5 +163,18 @@ export class SidePanelComponent {
       this.game.loadFromRLE(text);
     };
     reader.readAsText(file);
+  }
+
+  private hexToHue(hex: string): number {
+    const r = parseInt(hex.slice(1,3), 16) / 255;
+    const g = parseInt(hex.slice(3,5), 16) / 255;
+    const b = parseInt(hex.slice(5,7), 16) / 255;
+    const max = Math.max(r,g,b), min = Math.min(r,g,b);
+    if (max === min) return 0;
+    let h = 0;
+    if (max === r) h = (60 * ((g-b)/(max-min)) + 360) % 360;
+    else if (max === g) h = 60 * ((b-r)/(max-min)) + 120;
+    else h = 60 * ((r-g)/(max-min)) + 240;
+    return h;
   }
 }

--- a/src/app/services/game-of-life.ts
+++ b/src/app/services/game-of-life.ts
@@ -37,6 +37,9 @@ export class GameOfLifeService {
     survive: new Set([2,3]),
     born:    new Set([3])
   });
+  readonly stepCount = signal(0);
+  readonly bornTotal = signal(0);
+  readonly diedTotal = signal(0);
 
   setRules(survive: number[], born: number[]): void {
     this.rules.set({ survive: new Set(survive), born: new Set(born) });
@@ -103,7 +106,16 @@ export class GameOfLifeService {
       ( current.has(key) ? survive.has(n) : born.has(n) ) && nextCells.add(key);
     }
 
+    // Estadísticas
+    let born = 0;
+    let died = 0;
+    for (const k of nextCells) if (!current.has(k)) born++;
+    for (const k of current) if (!nextCells.has(k)) died++;
+
     this.cells.set(nextCells);
+    this.stepCount.update(v => v + 1);
+    this.bornTotal.update(v => v + born);
+    this.diedTotal.update(v => v + died);
 
     // Actualizar edades
     this.ages.update(prev => {
@@ -118,6 +130,9 @@ export class GameOfLifeService {
   clear(): void {
     this.cells.set(new Set());
     this.ages .set(new Map());
+    this.stepCount.set(0);
+    this.bornTotal.set(0);
+    this.diedTotal.set(0);
   }
 
   loadFromRLE(rleText: string): void {


### PR DESCRIPTION
## Summary
- show generation stats in info panel
- allow toggling colors and choosing base hue/background in side panel
- add backing signals and setters in `GameCanvas`
- track births/deaths in `GameOfLifeService`
- modernize SCSS for panels

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882df156b0c832bb0231c84f21328a2