### PR TITLE
Handle suspended audio context

### DIFF
--- a/src/app/services/music.spec.ts
+++ b/src/app/services/music.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+import { MusicService } from './music';
+
+describe('MusicService', () => {
+  let service: MusicService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MusicService);
+  });
+
+  it('resumes audio context when enabled', () => {
+    const audio = { state: 'suspended', resume: jasmine.createSpy('resume') } as any;
+    (service as any).audio = audio;
+    service.setEnabled(true);
+    expect(audio.resume).toHaveBeenCalled();
+  });
+
+  it('resumes on playCells if still suspended', () => {
+    const audio = { state: 'suspended', resume: jasmine.createSpy('resume') } as any;
+    (service as any).audio = audio;
+    service.setEnabled(true);
+    spyOn<any>(service, 'playRow');
+    service.playCells([[0,0]]);
+    expect(audio.resume).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/services/music.ts
+++ b/src/app/services/music.ts
@@ -18,6 +18,9 @@ export class MusicService {
 
   setEnabled(v: boolean): void {
     this.enabled.set(v);
+    if (v && this.audio.state === 'suspended') {
+      this.audio.resume();
+    }
   }
 
   setScale(name: string): void {
@@ -26,6 +29,9 @@ export class MusicService {
 
   playCells(cells: [number, number][]): void {
     if (!this.enabled()) return;
+    if (this.audio.state === 'suspended') {
+      this.audio.resume();
+    }
     for (const [, y] of cells) {
       this.playRow(y);
     }


### PR DESCRIPTION
## Summary
- resume the AudioContext when enabling music
- resume audio on the first playCells if needed
- add unit tests for MusicService to ensure resume occurs

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688405f5f738832bbfe6206d4a77a56f