### PR TITLE
Add configurable audio and techno drum track

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -9,5 +9,9 @@
   (stepsChange)="setSteps($event)"
   (rootNoteChange)="setRootNote($event)"
   (octavesChange)="setOctaves($event)"
-  (drumsEnabledChange)="setDrumsEnabled($event)"></side-panel>
+  (drumsEnabledChange)="setDrumsEnabled($event)"
+  (drumIntervalChange)="setDrumInterval($event)"
+  (kickPosChange)="setKickPosition($event)"
+  (snarePosChange)="setSnarePosition($event)"
+  (bpmRatioChange)="setBpmRatio($event)"></side-panel>
 <game-canvas #canvas></game-canvas>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -5,5 +5,9 @@
   (baseHueChange)="canvas.setBaseHue($event)"
   (bgColorChange)="canvas.setBgColor($event)"
   (musicEnabledChange)="canvas.setMusicEnabled($event)"
-  (scaleChange)="canvas.setScale($event)"></side-panel>
+  (scaleChange)="setScale($event)"
+  (stepsChange)="setSteps($event)"
+  (rootNoteChange)="setRootNote($event)"
+  (octavesChange)="setOctaves($event)"
+  (drumsEnabledChange)="setDrumsEnabled($event)"></side-panel>
 <game-canvas #canvas></game-canvas>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -38,4 +38,20 @@ export class App {
   setDrumsEnabled(v: boolean) {
     this.canvas.setDrumsEnabled(v);
   }
+
+  setDrumInterval(v: number) {
+    this.canvas.setDrumInterval(v);
+  }
+
+  setKickPosition(p: number) {
+    this.canvas.setKickPosition(p);
+  }
+
+  setSnarePosition(p: number) {
+    this.canvas.setSnarePosition(p);
+  }
+
+  setBpmRatio(r: number) {
+    this.canvas.setBpmRatio(r);
+  }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -22,4 +22,20 @@ export class App {
   setScale(name: string) {
     this.canvas.setScale(name);
   }
+
+  setSteps(steps: [number, number]) {
+    this.canvas.setSteps(steps[0], steps[1]);
+  }
+
+  setRootNote(n: number) {
+    this.canvas.setRootNote(n);
+  }
+
+  setOctaves(o: number) {
+    this.canvas.setOctaves(o);
+  }
+
+  setDrumsEnabled(v: boolean) {
+    this.canvas.setDrumsEnabled(v);
+  }
 }

--- a/src/app/components/game-canvas/game-canvas.ts
+++ b/src/app/components/game-canvas/game-canvas.ts
@@ -219,6 +219,22 @@ export class GameCanvasComponent implements AfterViewInit, OnDestroy {
     this.music.setDrumsEnabled(v);
   }
 
+  setDrumInterval(n: number): void {
+    this.music.setDrumInterval(n);
+  }
+
+  setKickPosition(p: number): void {
+    this.music.setKickPosition(p);
+  }
+
+  setSnarePosition(p: number): void {
+    this.music.setSnarePosition(p);
+  }
+
+  setBpmRatio(r: number): void {
+    this.music.setBpmRatio(r);
+  }
+
   /** Recibe patrón desde el side‑panel */
   selectPattern(coords: [number, number][]): void {
     this.patternToPlace = coords;

--- a/src/app/components/game-canvas/game-canvas.ts
+++ b/src/app/components/game-canvas/game-canvas.ts
@@ -59,6 +59,10 @@ export class GameCanvasComponent implements AfterViewInit, OnDestroy {
         const born = this.game.newbornCells();
         this.music.playCells(born);
       });
+      effect(() => {
+        this.game.stepCount();
+        this.music.tick(this.speed);
+      });
     });
 
     this.handleURLMessage();
@@ -197,6 +201,22 @@ export class GameCanvasComponent implements AfterViewInit, OnDestroy {
 
   setScale(name: string): void {
     this.music.setScale(name);
+  }
+
+  setSteps(h: number, v: number): void {
+    this.music.setSteps(h, v);
+  }
+
+  setRootNote(n: number): void {
+    this.music.setRootNote(n);
+  }
+
+  setOctaves(o: number): void {
+    this.music.setOctaves(o);
+  }
+
+  setDrumsEnabled(v: boolean): void {
+    this.music.setDrumsEnabled(v);
   }
 
   /** Recibe patrón desde el side‑panel */

--- a/src/app/components/side-panel/side-panel.html
+++ b/src/app/components/side-panel/side-panel.html
@@ -101,4 +101,6 @@
     <h3>Importar RLE</h3>
     <input type="file" accept=".rle,.lif" (change)="onRLEFileSelected($event)"  />
   </div>
+  <br/>
+  <br/>
 </div>

--- a/src/app/components/side-panel/side-panel.html
+++ b/src/app/components/side-panel/side-panel.html
@@ -58,6 +58,25 @@
       <option value="dorian">Dórico</option>
     </select>
   </label>
+  <label>
+    Paso X:
+    <input type="number" [value]="hStep()" (input)="onHStepChange($event)" />
+  </label>
+  <label>
+    Paso Y:
+    <input type="number" [value]="vStep()" (input)="onVStepChange($event)" />
+  </label>
+  <label>
+    Nota raíz:
+    <input type="number" [value]="rootNote()" (input)="onRootNoteChange($event)" />
+  </label>
+  <label>
+    Octavas:
+    <input type="number" min="1" [value]="octaves()" (input)="onOctavesChange($event)" />
+  </label>
+  <label>
+    <input type="checkbox" [checked]="drumsEnabled()" (change)="onDrumsEnabledChange($event)" /> Drum track
+  </label>
 
     <h3>Controles</h3>
     <button type="button" (click)="start.emit()">Play</button>

--- a/src/app/components/side-panel/side-panel.html
+++ b/src/app/components/side-panel/side-panel.html
@@ -77,6 +77,22 @@
   <label>
     <input type="checkbox" [checked]="drumsEnabled()" (change)="onDrumsEnabledChange($event)" /> Drum track
   </label>
+  <label>
+    Pasos del compás:
+    <input type="number" min="1" [value]="drumInterval()" (input)="onDrumIntervalChange($event)" />
+  </label>
+  <label>
+    Posición bombo:
+    <input type="number" [value]="kickPos()" (input)="onKickPosChange($event)" />
+  </label>
+  <label>
+    Posición redoblante:
+    <input type="number" [value]="snarePos()" (input)="onSnarePosChange($event)" />
+  </label>
+  <label>
+    BPM por velocidad:
+    <input type="number" min="1" [value]="bpmRatio()" (input)="onBpmRatioChange($event)" />
+  </label>
 
     <h3>Controles</h3>
     <button type="button" (click)="start.emit()">Play</button>

--- a/src/app/components/side-panel/side-panel.scss
+++ b/src/app/components/side-panel/side-panel.scss
@@ -1,6 +1,8 @@
 .menu-container {
   position: absolute;
   inset: 0 0 auto 0;
+  margin-bottom: 50px;
+  height: 100vh;
 }
 
 .menu-toggle {
@@ -17,12 +19,12 @@
 
 .panel {
   z-index: 10;
-  overflow: hidden;
   width: 250px;
   padding: 1rem;
   background: #f5f5f5;
-  height: 100vh;
   position: absolute;
+  height: 100%;
+  overflow-y: auto;
   top: 0;
   left: 0;
   transform: translateX(-105%);

--- a/src/app/components/side-panel/side-panel.ts
+++ b/src/app/components/side-panel/side-panel.ts
@@ -149,6 +149,10 @@ export class SidePanelComponent {
   rootNote = signal(60);
   octaves = signal(5);
   drumsEnabled = signal(false);
+  drumInterval = signal(16);
+  kickPos = signal(0);
+  snarePos = signal(8);
+  bpmRatio = signal(60);
 
     // 1) Lista de presets, con “Conway’s Life” seleccionado por defecto
   rulePresets: RulePreset[] = [
@@ -178,6 +182,10 @@ export class SidePanelComponent {
   @Output() rootNoteChange = new EventEmitter<number>();
   @Output() octavesChange = new EventEmitter<number>();
   @Output() drumsEnabledChange = new EventEmitter<boolean>();
+  @Output() drumIntervalChange = new EventEmitter<number>();
+  @Output() kickPosChange = new EventEmitter<number>();
+  @Output() snarePosChange = new EventEmitter<number>();
+  @Output() bpmRatioChange = new EventEmitter<number>();
 
   constructor(public game: GameOfLifeService) {
     // cada vez que cambien survive/born aplico reglas automáticamente
@@ -257,6 +265,30 @@ export class SidePanelComponent {
     const v = (e.target as HTMLInputElement).checked;
     this.drumsEnabled.set(v);
     this.drumsEnabledChange.emit(v);
+  }
+
+  onDrumIntervalChange(e: Event) {
+    const v = Math.max(1, Math.floor(+(<HTMLInputElement>e.target).value));
+    this.drumInterval.set(v);
+    this.drumIntervalChange.emit(v);
+  }
+
+  onKickPosChange(e: Event) {
+    const v = Math.floor(+(<HTMLInputElement>e.target).value);
+    this.kickPos.set(v);
+    this.kickPosChange.emit(v);
+  }
+
+  onSnarePosChange(e: Event) {
+    const v = Math.floor(+(<HTMLInputElement>e.target).value);
+    this.snarePos.set(v);
+    this.snarePosChange.emit(v);
+  }
+
+  onBpmRatioChange(e: Event) {
+    const v = Math.max(1, +(e.target as HTMLInputElement).value);
+    this.bpmRatio.set(v);
+    this.bpmRatioChange.emit(v);
   }
 
   onScaleChange(e: Event) {

--- a/src/app/components/side-panel/side-panel.ts
+++ b/src/app/components/side-panel/side-panel.ts
@@ -144,6 +144,11 @@ export class SidePanelComponent {
   background = signal('#ffffff');
   musicEnabled = signal(false);
   scale = signal('major');
+  hStep = signal(1);
+  vStep = signal(2);
+  rootNote = signal(60);
+  octaves = signal(5);
+  drumsEnabled = signal(false);
 
     // 1) Lista de presets, con “Conway’s Life” seleccionado por defecto
   rulePresets: RulePreset[] = [
@@ -169,6 +174,10 @@ export class SidePanelComponent {
   @Output() bgColorChange = new EventEmitter<string>();
   @Output() musicEnabledChange = new EventEmitter<boolean>();
   @Output() scaleChange = new EventEmitter<string>();
+  @Output() stepsChange = new EventEmitter<[number, number]>();
+  @Output() rootNoteChange = new EventEmitter<number>();
+  @Output() octavesChange = new EventEmitter<number>();
+  @Output() drumsEnabledChange = new EventEmitter<boolean>();
 
   constructor(public game: GameOfLifeService) {
     // cada vez que cambien survive/born aplico reglas automáticamente
@@ -218,6 +227,36 @@ export class SidePanelComponent {
     const v = (e.target as HTMLInputElement).checked;
     this.musicEnabled.set(v);
     this.musicEnabledChange.emit(v);
+  }
+
+  onHStepChange(e: Event) {
+    const v = +(e.target as HTMLInputElement).value;
+    this.hStep.set(v);
+    this.stepsChange.emit([v, this.vStep()]);
+  }
+
+  onVStepChange(e: Event) {
+    const v = +(e.target as HTMLInputElement).value;
+    this.vStep.set(v);
+    this.stepsChange.emit([this.hStep(), v]);
+  }
+
+  onRootNoteChange(e: Event) {
+    const v = +(e.target as HTMLInputElement).value;
+    this.rootNote.set(v);
+    this.rootNoteChange.emit(v);
+  }
+
+  onOctavesChange(e: Event) {
+    const v = Math.max(1, Math.floor(+((e.target as HTMLInputElement).value)));
+    this.octaves.set(v);
+    this.octavesChange.emit(v);
+  }
+
+  onDrumsEnabledChange(e: Event) {
+    const v = (e.target as HTMLInputElement).checked;
+    this.drumsEnabled.set(v);
+    this.drumsEnabledChange.emit(v);
   }
 
   onScaleChange(e: Event) {


### PR DESCRIPTION
## Summary
- allow customizing musical parameters via the side panel
- add techno-style drum track synced to generation speed
- expose new audio settings in the root component
- tick the music service on each generation

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885c5a99c94832b8c9c2fefd15a354e